### PR TITLE
Properly render JSONB fields instead of showing [Object object]

### DIFF
--- a/src/ResultTable.svelte
+++ b/src/ResultTable.svelte
@@ -51,6 +51,7 @@
   const formatters = {
     "date": (s) => dateFormatter.format(new Date(s)),
     "timestamp": (s) => timestampFormatter.format(new Date(s)),
+    "jsonb": (s) => JSON.stringify(s),
   }
 
   function getFormatter(sqlType) {


### PR DESCRIPTION
This PR stringifies JSON fields so that the contents can be seen instead of it just showing `[Object object]` etc